### PR TITLE
Fix link hover color in App.css

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -72,7 +72,7 @@
   }
 
   a {
-    @apply text-green hover:text-green-2 underline transition-colors;
+    @apply text-green hover:text-green-light underline transition-colors;
   }
 }
 


### PR DESCRIPTION
Update the hover color class for links to use the correct variable, ensuring consistent styling.